### PR TITLE
v4.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,12 @@ Next to each version number, you can see if the version is required or recommend
 
 # Change log
 
-## v4.0.2 (2025-12-16) <sub>$${\color{green}recommended}$$</sub>
+## v4.0.3 (2026-08-27) <sub>$${\color{red}required}$$</sub>
+
+- Resolved an edge case where a rerun after manual abort could overlap with lingering threads from the previous job and corrupt index updates.
+- Updated Coveo search token retrieval to support JWT-based authentication while preserving legacy principal fallback.
+
+## v4.0.2 (2026-07-06) <sub>$${\color{green}recommended}$$</sub>
 
 - Added support for single-source/multi-market approach
 - Minor changes to improve readability and maintainability

--- a/coveo/coveocc/project.properties
+++ b/coveo/coveocc/project.properties
@@ -15,4 +15,4 @@ ext.coveocc.extension.webmodule.webroot=/occ/v2
 
 coveocc.searchtoken.path=/rest/search/v2/token
 
-coveocc.header.useragent=CoSAPTokenConnector/v4.0.2
+coveocc.header.useragent=CoSAPTokenConnector/v4.0.3

--- a/coveo/coveocc/src/com/coveo/controllers/SearchTokenController.java
+++ b/coveo/coveocc/src/com/coveo/controllers/SearchTokenController.java
@@ -14,6 +14,7 @@ import org.apache.log4j.Logger;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -57,6 +58,16 @@ public class SearchTokenController {
 
     private String getUserId() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        return authentication.getPrincipal().toString();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "anonymous";
+        }
+
+        if (authentication.getPrincipal() instanceof Jwt jwt) {
+            // choose the claim that actually contains the commerce user id
+            return jwt.getClaimAsString("sub");
+        } else {
+            return authentication.getPrincipal().toString();
+        }
     }
 }

--- a/coveo/searchprovidercoveosearchservices/project.properties
+++ b/coveo/searchprovidercoveosearchservices/project.properties
@@ -23,4 +23,4 @@ coveo.multimarket.singlesource=false
 # Can be updated in the local.properties to adjust the interval.
 coveo.document.stream.log.interval.percentage=20
 
-coveo.header.useragent=CoSAPSearchProvider/v4.0.2
+coveo.header.useragent=CoSAPSearchProvider/v4.0.3

--- a/coveo/searchprovidercoveosearchservices/src/com/coveo/service/impl/CoveoSearchSnSearchProvider.java
+++ b/coveo/searchprovidercoveosearchservices/src/com/coveo/service/impl/CoveoSearchSnSearchProvider.java
@@ -27,21 +27,22 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class CoveoSearchSnSearchProvider extends AbstractSnSearchProvider<CoveoSearchSnSearchProviderConfiguration> implements InitializingBean {
 
     private static final Logger LOG = Logger.getLogger(CoveoSearchSnSearchProvider.class);
 
-    private final Map<String, CoveoStreamServiceStrategy> streamServiceStrategyMap = new HashMap<>();
+    private final Map<String, CoveoStreamServiceStrategy> streamServiceStrategyMap = new ConcurrentHashMap<>();
 
-    private final List<SnIndexerOperation> snIndexerOperations = new ArrayList<>();
+    private final List<SnIndexerOperation> snIndexerOperations = new CopyOnWriteArrayList<>();
 
     private Boolean singleSourceEnabled;
 
@@ -80,8 +81,8 @@ public class CoveoSearchSnSearchProvider extends AbstractSnSearchProvider<CoveoS
             LOG.debug("Getting Indexer Operation with id " + indexerOperationId);
         }
         return snIndexerOperations.stream()
-                .filter(op -> op.getId().equals(indexerOperationId))
-                .findFirst();
+                                  .filter(op -> op.getId().equals(indexerOperationId))
+                                  .findFirst();
     }
 
     @Override
@@ -107,7 +108,7 @@ public class CoveoSearchSnSearchProvider extends AbstractSnSearchProvider<CoveoS
             }
         }
 
-        if (streamServiceStrategyMap.isEmpty()) {
+        if (streamServiceStrategyMap.get(indexerOperation.getIndexId()) == null) {
             LOG.error("No stream service found for the index operation");
             throw new SnException("error creating client service");
         }
@@ -125,9 +126,9 @@ public class CoveoSearchSnSearchProvider extends AbstractSnSearchProvider<CoveoS
 
     private static SnIndexerOperation createSnIndexerOperation(SnContext context, SnIndexerOperationType indexerOperationType) {
         SnIndexerOperation indexerOperation = new SnIndexerOperation();
-        // Here we are using the combination of the index type id and the operation type code to create a unique index id
-        // This will then be used to identify the stream service to use for the operation within a map
-        indexerOperation.setId(context.getIndexType().getId() + indexerOperationType.getCode());
+        // A UUID suffix ensures each run gets its own unique key in the streamServiceStrategyMap,
+        // preventing concurrent runs of the same index type from overwriting each other's entries.
+        indexerOperation.setId(context.getIndexType().getId() + indexerOperationType.getCode() + UUID.randomUUID());
         // We need to set this the same as the ID because this is the value passed into the commit method
         indexerOperation.setIndexId(indexerOperation.getId());
         indexerOperation.setIndexTypeId(context.getIndexType().getId());
@@ -146,6 +147,7 @@ public class CoveoSearchSnSearchProvider extends AbstractSnSearchProvider<CoveoS
     @Override
     public void completeIndexerOperation(SnContext context, String indexerOperationId) throws SnException {
         LOG.info(String.format("The indexer operation %s has been completed", indexerOperationId));
+        cleanupIndexerOperation(indexerOperationId);
     }
 
     @Override
@@ -157,6 +159,7 @@ public class CoveoSearchSnSearchProvider extends AbstractSnSearchProvider<CoveoS
             }
         }
         LOG.warn("No items have been updated in the index");
+        cleanupIndexerOperation(indexerOperationId);
     }
 
     @Override
@@ -168,6 +171,12 @@ public class CoveoSearchSnSearchProvider extends AbstractSnSearchProvider<CoveoS
             }
         }
         LOG.warn("No items have been updated in the index");
+        cleanupIndexerOperation(indexerOperationId);
+    }
+
+    private void cleanupIndexerOperation(String indexerOperationId) {
+        streamServiceStrategyMap.remove(indexerOperationId);
+        snIndexerOperations.removeIf(op -> op.getId().equals(indexerOperationId));
     }
 
     @Override
@@ -215,9 +224,16 @@ public class CoveoSearchSnSearchProvider extends AbstractSnSearchProvider<CoveoS
         if (LOG.isDebugEnabled()) LOG.debug("Closing Service");
         try {
             CoveoStreamServiceStrategy streamServiceStrategy = streamServiceStrategyMap.get(indexId);
-            streamServiceStrategy.closeServices();
-        } catch (IOException | InterruptedException| NoOpenStreamException | NoOpenFileContainerException exception) {
-            LOG.error("There was an issue closing one of the streams. We will continue to close the remaining streams", exception);
+            if (streamServiceStrategy != null) {
+                streamServiceStrategy.closeServices();
+            } else {
+                LOG.warn("No stream service strategy found for indexId: " + indexId);
+            }
+        } catch (InterruptedException exception) {
+            LOG.error("Stream closing was interrupted. Aborting close operation.", exception);
+            Thread.currentThread().interrupt();
+        } catch (IOException | NoOpenStreamException | NoOpenFileContainerException exception) {
+            LOG.error("There was an issue closing one of the streams.", exception);
         }
     }
 

--- a/coveo/searchprovidercoveosearchservices/testsrc/com/coveo/service/impl/CoveoSearchSnSearchProviderTest.java
+++ b/coveo/searchprovidercoveosearchservices/testsrc/com/coveo/service/impl/CoveoSearchSnSearchProviderTest.java
@@ -31,10 +31,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -91,6 +93,27 @@ class CoveoSearchSnSearchProviderTest {
         when(snContext.getAttributes()).thenReturn(attributes);
     }
 
+    private SnContext createContext(CoveoProductStreamServiceStrategy<?> rebuildStrategy,
+                                    CoveoProductStreamServiceStrategy<?> updateStrategy,
+                                    String composedType) {
+        SnContext context = mock(SnContext.class);
+        SnIndexType indexType = mock(SnIndexType.class);
+        when(indexType.getId()).thenReturn(INDEX_TYPE_ID);
+        when(indexType.getItemComposedType()).thenReturn(composedType);
+        when(context.getIndexType()).thenReturn(indexType);
+
+        when(configurationService.getConfiguration()).thenReturn(configuration);
+        when(configuration.getString(SearchprovidercoveosearchservicesConstants.SUPPORTED_AVAILABILITY_TYPES_CODE)).thenReturn(
+                SUPPORTED_AVAILABILITY_TYPES_CODE);
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put(SearchprovidercoveosearchservicesConstants.COVEO_PRODUCT_REBUILD_STREAM_SERVICES_KEY, rebuildStrategy);
+        attributes.put(SearchprovidercoveosearchservicesConstants.COVEO_PRODUCT_UPDATE_STREAM_SERVICES_KEY, updateStrategy);
+        attributes.put(SearchprovidercoveosearchservicesConstants.COVEO_SINGLE_SOURCE_ENABLED_KEY, Boolean.FALSE);
+        when(context.getAttributes()).thenReturn(attributes);
+        return context;
+    }
+
     @Test
     void testCreateIndex() throws SnException {
         when(snIndexType.getId()).thenReturn(INDEX_TYPE_ID);
@@ -108,10 +131,10 @@ class CoveoSearchSnSearchProviderTest {
         when(snIndexType.getItemComposedType()).thenReturn("Warehouse");
         List<SnDocumentBatchOperationResponse> responses = new ArrayList<>();
         when(coveoAvailabilityRebuildStreamServiceStrategy.pushDocuments(anyList(), eq(Boolean.FALSE))).thenReturn(responses);
-        coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
+        SnIndexerOperation operation = coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
         SnDocumentBatchRequest request = new SnDocumentBatchRequest();
         request.setRequests(new ArrayList<>());
-        coveoSearchSnSearchProvider.executeDocumentBatch(snContext, INDEX_TYPE_ID + SnIndexerOperationType.FULL, request, INDEX_TYPE_ID + SnIndexerOperationType.FULL);
+        coveoSearchSnSearchProvider.executeDocumentBatch(snContext, operation.getIndexId(), request, operation.getId());
         verify(coveoAvailabilityRebuildStreamServiceStrategy, times(1)).pushDocuments(Collections.emptyList(), Boolean.FALSE);
         verify(coveoAvailabilityUpdateStreamServiceStrategy, times(0)).pushDocuments(Collections.emptyList(), Boolean.FALSE);
     }
@@ -122,10 +145,10 @@ class CoveoSearchSnSearchProviderTest {
         when(snIndexType.getItemComposedType()).thenReturn("Warehouse");
         List<SnDocumentBatchOperationResponse> responses = new ArrayList<>();
         when(coveoAvailabilityUpdateStreamServiceStrategy.pushDocuments(anyList(), eq(Boolean.TRUE))).thenReturn(responses);
-        coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.INCREMENTAL, DOCS_TO_INDEX);
+        SnIndexerOperation operation = coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.INCREMENTAL, DOCS_TO_INDEX);
         SnDocumentBatchRequest request = new SnDocumentBatchRequest();
         request.setRequests(new ArrayList<>());
-        coveoSearchSnSearchProvider.executeDocumentBatch(snContext, INDEX_TYPE_ID + SnIndexerOperationType.INCREMENTAL, request, INDEX_TYPE_ID + SnIndexerOperationType.INCREMENTAL);
+        coveoSearchSnSearchProvider.executeDocumentBatch(snContext, operation.getIndexId(), request, operation.getId());
         verify(coveoAvailabilityRebuildStreamServiceStrategy, times(0)).pushDocuments(Collections.emptyList(), Boolean.TRUE);
         verify(coveoAvailabilityUpdateStreamServiceStrategy, times(1)).pushDocuments(Collections.emptyList(), Boolean.TRUE);
     }
@@ -134,8 +157,8 @@ class CoveoSearchSnSearchProviderTest {
     void testCommit_AvailabilityFullIndexOperation() throws Exception {
         setUpTestContext(Boolean.FALSE);
         when(snIndexType.getItemComposedType()).thenReturn("Warehouse");
-        coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
-        coveoSearchSnSearchProvider.commit(snContext, INDEX_TYPE_ID + SnIndexerOperationType.FULL);
+        SnIndexerOperation operation = coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
+        coveoSearchSnSearchProvider.commit(snContext, operation.getIndexId());
         verify(coveoAvailabilityRebuildStreamServiceStrategy, times(1)).closeServices();
         verify(coveoAvailabilityUpdateStreamServiceStrategy, times(0)).closeServices();
     }
@@ -144,8 +167,8 @@ class CoveoSearchSnSearchProviderTest {
     void testCommit_AvailabilityIncrementalIndexOperation() throws Exception {
         setUpTestContext(Boolean.FALSE);
         when(snIndexType.getItemComposedType()).thenReturn("Warehouse");
-        coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.INCREMENTAL, DOCS_TO_INDEX);
-        coveoSearchSnSearchProvider.commit(snContext, INDEX_TYPE_ID + SnIndexerOperationType.INCREMENTAL);
+        SnIndexerOperation operation = coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.INCREMENTAL, DOCS_TO_INDEX);
+        coveoSearchSnSearchProvider.commit(snContext, operation.getIndexId());
         verify(coveoAvailabilityRebuildStreamServiceStrategy, times(0)).closeServices();
         verify(coveoAvailabilityUpdateStreamServiceStrategy, times(1)).closeServices();
     }
@@ -156,8 +179,10 @@ class CoveoSearchSnSearchProviderTest {
         when(snIndexType.getItemComposedType()).thenReturn("Product");
         final SnIndexerOperation operation = coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
         assertEquals(INDEX_TYPE_ID, operation.getIndexTypeId());
-        assertEquals(INDEX_TYPE_ID + SnIndexerOperationType.FULL, operation.getIndexId());
-        assertEquals(INDEX_TYPE_ID + SnIndexerOperationType.FULL, operation.getId());
+        assertTrue(operation.getId().startsWith(INDEX_TYPE_ID + SnIndexerOperationType.FULL),
+                "Operation ID should start with indexTypeId + operationType");
+        assertEquals(operation.getId(), operation.getIndexId(),
+                "indexId should equal id so commit() can locate the correct stream");
         assertEquals(SnIndexerOperationType.FULL, operation.getOperationType());
         assertEquals(SnIndexerOperationStatus.RUNNING, operation.getStatus());
     }
@@ -168,10 +193,10 @@ class CoveoSearchSnSearchProviderTest {
         when(snIndexType.getItemComposedType()).thenReturn("Product");
         List<SnDocumentBatchOperationResponse> responses = new ArrayList<>();
         when(coveoProductRebuildStreamServiceStrategy.pushDocuments(anyList(), eq(Boolean.FALSE))).thenReturn(responses);
-        coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
+        SnIndexerOperation operation = coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
         SnDocumentBatchRequest request = new SnDocumentBatchRequest();
         request.setRequests(new ArrayList<>());
-        coveoSearchSnSearchProvider.executeDocumentBatch(snContext, INDEX_TYPE_ID + SnIndexerOperationType.FULL, request, INDEX_TYPE_ID + SnIndexerOperationType.FULL);
+        coveoSearchSnSearchProvider.executeDocumentBatch(snContext, operation.getIndexId(), request, operation.getId());
         verify(coveoProductRebuildStreamServiceStrategy, times(1)).pushDocuments(Collections.emptyList(), Boolean.FALSE);
         verify(coveoProductUpdateStreamServiceStrategy, times(0)).pushDocuments(Collections.emptyList(), Boolean.FALSE);
     }
@@ -182,10 +207,10 @@ class CoveoSearchSnSearchProviderTest {
         when(snIndexType.getItemComposedType()).thenReturn("Product");
         List<SnDocumentBatchOperationResponse> responses = new ArrayList<>();
         when(coveoProductUpdateStreamServiceStrategy.pushDocuments(anyList(), eq(Boolean.FALSE))).thenReturn(responses);
-        coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.INCREMENTAL, DOCS_TO_INDEX);
+        SnIndexerOperation operation = coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.INCREMENTAL, DOCS_TO_INDEX);
         SnDocumentBatchRequest request = new SnDocumentBatchRequest();
         request.setRequests(new ArrayList<>());
-        coveoSearchSnSearchProvider.executeDocumentBatch(snContext, INDEX_TYPE_ID + SnIndexerOperationType.INCREMENTAL, request, INDEX_TYPE_ID + SnIndexerOperationType.INCREMENTAL);
+        coveoSearchSnSearchProvider.executeDocumentBatch(snContext, operation.getIndexId(), request, operation.getId());
         verify(coveoProductRebuildStreamServiceStrategy, times(0)).pushDocuments(Collections.emptyList(), Boolean.FALSE);
         verify(coveoProductUpdateStreamServiceStrategy, times(1)).pushDocuments(Collections.emptyList(), Boolean.FALSE);
     }
@@ -194,8 +219,8 @@ class CoveoSearchSnSearchProviderTest {
     void testCommit_ProductFullIndexOperation() throws Exception {
         setUpTestContext(Boolean.FALSE);
         when(snIndexType.getItemComposedType()).thenReturn("Product");
-        coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
-        coveoSearchSnSearchProvider.commit(snContext, INDEX_TYPE_ID + SnIndexerOperationType.FULL);
+        SnIndexerOperation operation = coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
+        coveoSearchSnSearchProvider.commit(snContext, operation.getIndexId());
         verify(coveoProductRebuildStreamServiceStrategy, times(1)).closeServices();
         verify(coveoProductUpdateStreamServiceStrategy, times(0)).closeServices();
     }
@@ -204,9 +229,56 @@ class CoveoSearchSnSearchProviderTest {
     void testCommit_ProductIncrementalIndexOperation() throws Exception {
         setUpTestContext(Boolean.FALSE);
         when(snIndexType.getItemComposedType()).thenReturn("Product");
-        coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.INCREMENTAL, DOCS_TO_INDEX);
-        coveoSearchSnSearchProvider.commit(snContext, INDEX_TYPE_ID + SnIndexerOperationType.INCREMENTAL);
+        SnIndexerOperation operation = coveoSearchSnSearchProvider.createIndexerOperation(snContext, SnIndexerOperationType.INCREMENTAL, DOCS_TO_INDEX);
+        coveoSearchSnSearchProvider.commit(snContext, operation.getIndexId());
         verify(coveoProductRebuildStreamServiceStrategy, times(0)).closeServices();
         verify(coveoProductUpdateStreamServiceStrategy, times(1)).closeServices();
+    }
+
+    @Test
+    void testConcurrentFullIndexRuns_EachRunCommitsItsOwnStream() throws Exception {
+        CoveoProductStreamServiceStrategy<CoveoRebuildStreamService> run1Strategy = mock(CoveoProductStreamServiceStrategy.class);
+        CoveoProductStreamServiceStrategy<CoveoRebuildStreamService> run2Strategy = mock(CoveoProductStreamServiceStrategy.class);
+        CoveoProductStreamServiceStrategy<CoveoUpdateStreamService> updateStrategy = mock(CoveoProductStreamServiceStrategy.class);
+
+        SnContext run1Context = createContext(run1Strategy, updateStrategy, "Product");
+        SnContext run2Context = createContext(run2Strategy, updateStrategy, "Product");
+
+        SnIndexerOperation run1Op = coveoSearchSnSearchProvider.createIndexerOperation(run1Context, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
+        SnIndexerOperation run2Op = coveoSearchSnSearchProvider.createIndexerOperation(run2Context, SnIndexerOperationType.FULL, DOCS_TO_INDEX);
+
+        assertNotEquals(run1Op.getId(), run2Op.getId(),
+                "Concurrent runs must have unique operation IDs to avoid map key collision");
+
+        coveoSearchSnSearchProvider.commit(run1Context, run1Op.getIndexId());
+        verify(run1Strategy, times(1)).closeServices();
+        verify(run2Strategy, times(0)).closeServices();
+
+        coveoSearchSnSearchProvider.commit(run2Context, run2Op.getIndexId());
+        verify(run2Strategy, times(1)).closeServices();
+    }
+
+    @Test
+    void testConcurrentIncrementalIndexRuns_EachRunCommitsItsOwnStream() throws Exception {
+        CoveoProductStreamServiceStrategy<CoveoRebuildStreamService> rebuildStrategy = mock(CoveoProductStreamServiceStrategy.class);
+        CoveoProductStreamServiceStrategy<CoveoUpdateStreamService> run1Strategy = mock(CoveoProductStreamServiceStrategy.class);
+        CoveoProductStreamServiceStrategy<CoveoUpdateStreamService> run2Strategy = mock(CoveoProductStreamServiceStrategy.class);
+
+        SnContext run1Context = createContext(rebuildStrategy, run1Strategy, "Product");
+        SnContext run2Context = createContext(rebuildStrategy, run2Strategy, "Product");
+
+        SnIndexerOperation run1Op = coveoSearchSnSearchProvider.createIndexerOperation(run1Context, SnIndexerOperationType.INCREMENTAL, DOCS_TO_INDEX);
+        SnIndexerOperation run2Op = coveoSearchSnSearchProvider.createIndexerOperation(run2Context, SnIndexerOperationType.INCREMENTAL, DOCS_TO_INDEX);
+
+        assertNotEquals(run1Op.getId(), run2Op.getId(),
+                "Concurrent runs must have unique operation IDs to avoid map key collision");
+
+        coveoSearchSnSearchProvider.commit(run1Context, run1Op.getIndexId());
+        verify(run1Strategy, times(1)).closeServices();
+        verify(run2Strategy, times(0)).closeServices();
+
+        // Run 2 commits — must close only Run 2's stream
+        coveoSearchSnSearchProvider.commit(run2Context, run2Op.getIndexId());
+        verify(run2Strategy, times(1)).closeServices();
     }
 }


### PR DESCRIPTION
Resolves an edge case where a slow job has the status manually changes thereby allowing a second job to run concurrently which can add or remove documents incorrectly from the coveo index. It also updates the way we get the user id for the search token retrieval based on the authentication changes made in the JDK 21 upgrade